### PR TITLE
Do not include `file://` when opening local files

### DIFF
--- a/src/mat/openmatcommand.cpp
+++ b/src/mat/openmatcommand.cpp
@@ -139,7 +139,7 @@ int OpenMatCommand::run(const QStringList &arguments)
         }
 
         if (df) { // default app found
-            if (!df->startDetached(urlString)) {
+            if (!df->startDetached(isLocalFile ? localFilename : urlString)) {
                 std::cerr << qPrintable(
                         QSL("Error while running the default application (%1) for %2\n").arg(df->name(), urlString));
                 success = false;


### PR DESCRIPTION
Some apps may not open a local file when its path is prefixed by `file://`. Of course, that can be seen as a bug in them, but `gio open` doesn't trigger that bug because it doesn't include `file://`.

This patch can be tested with `qpdfview` as the default PDF handler. `gio open file://….pdf` doesn't trigger the problem of `qpdfview`, but `qtxdg-mat open file://….pdf` does (without the patch), and unfortunately, the problem is also triggered by any code that makes use of `QDesktopServices::openUrl()`.